### PR TITLE
Add note on Rust version requirement for examples

### DIFF
--- a/async-stream/README.md
+++ b/async-stream/README.md
@@ -40,7 +40,9 @@ async fn main() {
 }
 ```
 
-Streams may be returned by using `impl Stream<Item = T>`:
+The following examples require a Rust version >= 1.45 to allow [procedural macros in the statement position](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1450-2020-07-16).
+
+Streams may be returned by using `impl Stream<Item = T>`: 
 
 ```rust
 use async_stream::stream;


### PR DESCRIPTION
On versions prior to 1.45, the compiler would error with `procedural macros cannot be expanded to statements`.